### PR TITLE
Implement the OAuth2 Protocol provider for InfluxCloud

### DIFF
--- a/providers/influxcloud/influxcloud.go
+++ b/providers/influxcloud/influxcloud.go
@@ -1,5 +1,5 @@
 // Package influxdata implements the OAuth2 protocol for authenticating users through InfluxCloud.
-// It is based off of the influxcloud implementation.
+// It is based off of the github implementation.
 package influxcloud
 
 import (

--- a/providers/influxcloud/influxcloud.go
+++ b/providers/influxcloud/influxcloud.go
@@ -17,9 +17,11 @@ import (
 )
 
 const (
-	authURL         string = "https://github.com/login/oauth/authorize"
-	tokenURL        string = "https://github.com/login/oauth/access_token"
-	endpointProfile string = "https://api.github.com/user"
+	// The hard coded domain is difficult here because influx cloud has an acceptance
+	// domain that is different and we will need that for enterprise development.
+	authURL         string = "https://cloud.influxdata.com/oauth/authorize"
+	tokenURL        string = "https://cloud.influxdata.com/oauth/access_token"
+	endpointProfile string = "https://cloud.influxdata.com/api/v1/user"
 )
 
 // New creates a new Github provider, and sets up important connection details.

--- a/providers/influxcloud/influxcloud.go
+++ b/providers/influxcloud/influxcloud.go
@@ -1,0 +1,148 @@
+// Package influxdata implements the OAuth2 protocol for authenticating users through InfluxCloud.
+// It is based off of the influxcloud implementation.
+package influxcloud
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
+)
+
+const (
+	authURL         string = "https://github.com/login/oauth/authorize"
+	tokenURL        string = "https://github.com/login/oauth/access_token"
+	endpointProfile string = "https://api.github.com/user"
+)
+
+// New creates a new Github provider, and sets up important connection details.
+// You should always call `influxcloud.New` to get a new Provider. Never try to create
+// one manually.
+func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
+	p := &Provider{
+		ClientKey:   clientKey,
+		Secret:      secret,
+		CallbackURL: callbackURL,
+	}
+	p.config = newConfig(p, scopes)
+	return p
+}
+
+// Provider is the implementation of `goth.Provider` for accessing Github.
+type Provider struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	config      *oauth2.Config
+}
+
+// Name is the name used to retrieve this provider later.
+func (p *Provider) Name() string {
+	return "influxcloud"
+}
+
+// Debug is a no-op for the influxcloud package.
+func (p *Provider) Debug(debug bool) {}
+
+// BeginAuth asks Github for an authentication end-point.
+func (p *Provider) BeginAuth(state string) (goth.Session, error) {
+	url := p.config.AuthCodeURL(state)
+	session := &Session{
+		AuthURL: url,
+	}
+	return session, nil
+}
+
+// FetchUser will go to Github and access basic information about the user.
+func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
+	sess := session.(*Session)
+	user := goth.User{
+		AccessToken: sess.AccessToken,
+		Provider:    p.Name(),
+	}
+
+	response, err := http.Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))
+	if err != nil {
+		if response != nil {
+			response.Body.Close()
+		}
+		return user, err
+	}
+	defer response.Body.Close()
+
+	bits, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return user, err
+	}
+
+	err = json.NewDecoder(bytes.NewReader(bits)).Decode(&user.RawData)
+	if err != nil {
+		return user, err
+	}
+
+	err = userFromReader(bytes.NewReader(bits), &user)
+	return user, err
+}
+
+func userFromReader(reader io.Reader, user *goth.User) error {
+	u := struct {
+		ID       int    `json:"id"`
+		Email    string `json:"email"`
+		Bio      string `json:"bio"`
+		Name     string `json:"name"`
+		Login    string `json:"login"`
+		Picture  string `json:"avatar_url"`
+		Location string `json:"location"`
+	}{}
+
+	err := json.NewDecoder(reader).Decode(&u)
+	if err != nil {
+		return err
+	}
+
+	user.Name = u.Name
+	user.NickName = u.Login
+	user.Email = u.Email
+	user.Description = u.Bio
+	user.AvatarURL = u.Picture
+	user.UserID = strconv.Itoa(u.ID)
+	user.Location = u.Location
+
+	return err
+}
+
+func newConfig(provider *Provider, scopes []string) *oauth2.Config {
+	c := &oauth2.Config{
+		ClientID:     provider.ClientKey,
+		ClientSecret: provider.Secret,
+		RedirectURL:  provider.CallbackURL,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  authURL,
+			TokenURL: tokenURL,
+		},
+		Scopes: []string{},
+	}
+
+	for _, scope := range scopes {
+		c.Scopes = append(c.Scopes, scope)
+	}
+
+	return c
+}
+
+//RefreshToken refresh token is not provided by influxcloud
+func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
+	return nil, errors.New("Refresh token is not provided by influxcloud")
+}
+
+//RefreshTokenAvailable refresh token is not provided by influxcloud
+func (p *Provider) RefreshTokenAvailable() bool {
+	return false
+}

--- a/providers/influxcloud/influxcloud_test.go
+++ b/providers/influxcloud/influxcloud_test.go
@@ -1,0 +1,59 @@
+package influxcloud_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/markbates/goth"
+	"github.com/markbates/goth/providers/influxcloud"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_New(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+
+	provider := influxcloudProvider()
+	a.Equal(provider.ClientKey, os.Getenv("INFLUXCLOUD_KEY"))
+	a.Equal(provider.Secret, os.Getenv("INFLUXCLOUD_SECRET"))
+	a.Equal(provider.CallbackURL, "/foo")
+}
+
+func Test_Implements_Provider(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+
+	a.Implements((*goth.Provider)(nil), influxcloudProvider())
+}
+
+func Test_BeginAuth(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+
+	provider := influxcloudProvider()
+	session, err := provider.BeginAuth("test_state")
+	s := session.(*influxcloud.Session)
+	a.NoError(err)
+	a.Contains(s.AuthURL, "github.com/login/oauth/authorize")
+	a.Contains(s.AuthURL, fmt.Sprintf("client_id=%s", os.Getenv("INFLUXCLOUD_KEY")))
+	a.Contains(s.AuthURL, "state=test_state")
+	a.Contains(s.AuthURL, "scope=user")
+}
+
+func Test_SessionFromJSON(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+
+	provider := influxcloudProvider()
+
+	s, err := provider.UnmarshalSession(`{"AuthURL":"http://github.com/auth_url","AccessToken":"1234567890"}`)
+	a.NoError(err)
+	session := s.(*influxcloud.Session)
+	a.Equal(session.AuthURL, "http://github.com/auth_url")
+	a.Equal(session.AccessToken, "1234567890")
+}
+
+func influxcloudProvider() *influxcloud.Provider {
+	return influxcloud.New(os.Getenv("INFLUXATA_KEY"), os.Getenv("INFLUXCLOUD_SECRET"), "/foo", "user")
+}

--- a/providers/influxcloud/influxcloud_test.go
+++ b/providers/influxcloud/influxcloud_test.go
@@ -35,7 +35,9 @@ func Test_BeginAuth(t *testing.T) {
 	session, err := provider.BeginAuth("test_state")
 	s := session.(*influxcloud.Session)
 	a.NoError(err)
-	a.Contains(s.AuthURL, "github.com/login/oauth/authorize")
+	//FIXME: we really need to be able to run this against the acceptance server, too.
+	// How should we do this? Maybe a test envvar switch?
+	a.Contains(s.AuthURL, "cloud.influxdata.com/oauth/authorize")
 	a.Contains(s.AuthURL, fmt.Sprintf("client_id=%s", os.Getenv("INFLUXCLOUD_KEY")))
 	a.Contains(s.AuthURL, "state=test_state")
 	a.Contains(s.AuthURL, "scope=user")
@@ -47,6 +49,7 @@ func Test_SessionFromJSON(t *testing.T) {
 
 	provider := influxcloudProvider()
 
+	//FIXME: What is this testing exactly?
 	s, err := provider.UnmarshalSession(`{"AuthURL":"http://github.com/auth_url","AccessToken":"1234567890"}`)
 	a.NoError(err)
 	session := s.(*influxcloud.Session)

--- a/providers/influxcloud/session.go
+++ b/providers/influxcloud/session.go
@@ -1,0 +1,57 @@
+package influxcloud
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
+)
+
+// Session stores data during the auth process with Github.
+type Session struct {
+	AuthURL     string
+	AccessToken string
+}
+
+// GetAuthURL will return the URL set by calling the `BeginAuth` function on the Github provider.
+func (s Session) GetAuthURL() (string, error) {
+	if s.AuthURL == "" {
+		return "", errors.New("an AuthURL has not be set")
+	}
+	return s.AuthURL, nil
+}
+
+// Authorize the session with Github and return the access token to be stored for future use.
+func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
+	p := provider.(*Provider)
+	token, err := p.config.Exchange(oauth2.NoContext, params.Get("code"))
+	if err != nil {
+		return "", err
+	}
+
+	if !token.Valid() {
+		return "", errors.New("Invalid token received from provider")
+	}
+
+	s.AccessToken = token.AccessToken
+	return token.AccessToken, err
+}
+
+// Marshal the session into a string
+func (s Session) Marshal() string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+func (s Session) String() string {
+	return s.Marshal()
+}
+
+// UnmarshalSession will unmarshal a JSON string into a session.
+func (p *Provider) UnmarshalSession(data string) (goth.Session, error) {
+	sess := &Session{}
+	err := json.NewDecoder(strings.NewReader(data)).Decode(sess)
+	return sess, err
+}

--- a/providers/influxcloud/session_test.go
+++ b/providers/influxcloud/session_test.go
@@ -1,0 +1,48 @@
+package influxcloud_test
+
+import (
+	"testing"
+
+	"github.com/markbates/goth"
+	"github.com/markbates/goth/providers/influxcloud"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Implements_Session(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	s := &influxcloud.Session{}
+
+	a.Implements((*goth.Session)(nil), s)
+}
+
+func Test_GetAuthURL(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	s := &influxcloud.Session{}
+
+	_, err := s.GetAuthURL()
+	a.Error(err)
+
+	s.AuthURL = "/foo"
+
+	url, _ := s.GetAuthURL()
+	a.Equal(url, "/foo")
+}
+
+func Test_ToJSON(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	s := &influxcloud.Session{}
+
+	data := s.Marshal()
+	a.Equal(data, `{"AuthURL":"","AccessToken":""}`)
+}
+
+func Test_String(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	s := &influxcloud.Session{}
+
+	a.Equal(s.String(), s.Marshal())
+}


### PR DESCRIPTION
It is based off of the github provider implementation.

The only concern I have with this PR is that the hard coded domain is (influxcloud.go:L22:24) difficult because InfluxCloud has an acceptance domain that is different and we will need that for developing our Integrations with other internal projects such as Influx Enterprise.

I'm also not sure exactly what we're testing on influxcloud_test.go:L40. @markbates, what is that about?
